### PR TITLE
add logger to milemarker dependencies

### DIFF
--- a/milemarker.gemspec
+++ b/milemarker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "logger"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
I was getting this warning when I loaded `milemarker`:

```
/app/vendor/bundle/ruby/3.4.0/gems/milemarker-1.0.1/lib/milemarker.rb:4: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

This makes `logger` and app_dependency. I didn't tie it to a version because I assume it'd be fine?